### PR TITLE
build: switched to in-mem db in docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,3 @@ release/
 
 # VS Code
 .vscode/
-
-# docker-compose auth db
-auth-db/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,6 @@ services:
     image: storjlabs/gateway-mt:dev
     deploy:
       replicas: 1
-      resources:
-        limits:
-          cpus: '1.5'
-          memory: 1024M
-        reservations:
-          memory: 512M
       restart_policy:
         condition: on-failure
         max_attempts: 3
@@ -31,12 +25,6 @@ services:
     image: storjlabs/authservice:dev
     deploy:
       replicas: 1
-      resources:
-        limits:
-          cpus: '1.5'
-          memory: 1024M
-        reservations:
-          memory: 512M
       restart_policy:
         condition: on-failure
         max_attempts: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,12 +49,10 @@ services:
       - "9000:8000"
     command:
       - run
-      - --migration
       # this list can be updated from https://tardigrade.io/trusted-satellites
       - --allowed-satellites=12EayRS2V1kEsWESU9QMRseFhdxYxKicsiFmxrsLZHeLUtdps3S@us-central-1.tardigrade.io:7777,12L9ZFwhzVpuEKMUNUqkaTLGzwY9G24tbiigLiXpmZWKwmcNDDs@europe-west-1.tardigrade.io:7777,121RTSDpyNZVcEU84Ticf2L1ntiuUimbWgfATz21tuvgk3vzoA6@asia-east-1.tardigrade.io:7777,1wFTAgs9DP5RSnCqKV1eLf6N9wtk4EAtmN5DpSxcs8EjT69tGE@saltlake.tardigrade.io:7777,12rfG3sh9NCWiX3ivPjq2HtdLmbqCrvHVEzJubnzFzosMuawymB@europe-north-1.tardigrade.io:7777
       - --auth-token=staging
       - --public-url=http://localhost:9000
-      - --kv-backend=sqlite3:///app/db/authdb.db
       - --endpoint=http://localhost:7777
       # - --cert-file=/app/public.crt
       # - --key-file=/app/private.key


### PR DESCRIPTION
this is because the migration stuff isn't ready yet, so we'll switch back to sqlite3 as the default once it is.