### PR TITLE
Makefile: downgrade to go v1.15.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_VERSION ?= 1.16
+GO_VERSION ?= 1.15.7
 GOOS ?= linux
 GOARCH ?= amd64
 GOPATH ?= $(shell go env GOPATH)


### PR DESCRIPTION
As go v1.16 causes build failures for OSX binaries, we need to revert for now.