### PR TITLE
linksharing: add to local docker-compose

### DIFF
--- a/docker-local/docker-compose.yml
+++ b/docker-local/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_DB=dcstorj
   storjsim:
-    image: golang:1.16.0
+    image: golang:1.17.7
     entrypoint: /scripts/start-storj-sim.sh
     volumes:
       - localgopath:/go/storjpath
@@ -29,7 +29,7 @@ services:
       - postgres
       - redis
   authservice:
-    image: golang:1.16.0
+    image: golang:1.17.7
     entrypoint: /scripts/start-auth-service.sh
     volumes:
       - localgopath:/go/storjpath
@@ -43,7 +43,7 @@ services:
     env_file:
       - service.env
   gateway-mt:
-    image: golang:1.16.0
+    image: golang:1.17.7
     volumes:
       - localgopath:/go/storjpath
       - ${GATEWAY_SRC_DIR}:/code
@@ -59,6 +59,18 @@ services:
       - storjsim
       - authservice
       - tracing
+  linksharing:
+    image: golang:1.17.7
+    entrypoint: /scripts/start-linksharing.sh
+    volumes:
+      - localgopath:/go/storjpath
+      - ${GATEWAY_SRC_DIR}:/code
+      - ./start-linksharing.sh:/scripts/start-linksharing.sh
+    ports:
+      - "20020:20020"
+    depends_on:
+      - authservice
+      - storjsim
   tracing:
     image: jaegertracing/all-in-one:1.21
     ports:

--- a/docker-local/start-linksharing.sh
+++ b/docker-local/start-linksharing.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -xe
+
+cd /code
+go install -v storj.io/gateway-mt/cmd/linksharing
+
+linksharing run \
+    --auth-service.base-url http://authservice:20000 \
+    --auth-service.token super-secret \
+    --address=:20020 \
+    --public-url=http://localhost:20020 \
+    --log.level=debug

--- a/pkg/auth/peer.go
+++ b/pkg/auth/peer.go
@@ -110,6 +110,10 @@ func New(ctx context.Context, log *zap.Logger, config Config, configDir string) 
 		return nil, errs.New("allowed satellites parameter '--allowed-satellites' resolved to zero satellites")
 	}
 
+	for satelliteID := range allowedSats {
+		log.Debug("allowed satellite: " + satelliteID.String())
+	}
+
 	if config.Endpoint == "" {
 		return nil, errs.New("endpoint parameter '--endpoint' is required")
 	}


### PR DESCRIPTION
Add linksharing to docker-compose for testing locally.

Testing: run `docker-compose up --detach`.
Check the logs using `docker-compose logs --follow`
Visit http://localhost:8000

It lacks some good usage instructions but I'm not writing them now.

Change-Id: Ie1a193ee84ddb55e0431eaed48302150f28ce0dc